### PR TITLE
Fix for incorrect maven repository link

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,9 +8,8 @@ buildscript {
     }
 
     repositories {
-        maven {
-            url "gcs://snapengine-maven-publish/releases"
-        }
+        google()
+        mavenCentral()
     }
 
     dependencies {
@@ -68,9 +67,8 @@ android {
 }
 
 repositories {
-    maven {
-        url "gcs://snapengine-maven-publish/releases"
-    }
+    google()
+    mavenCentral()
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -104,9 +104,8 @@ android {
 }
 
 repositories {
-    maven {
-        url "gcs://snapengine-maven-publish/releases"
-    }
+    google()
+    mavenCentral()
 }
 
 dependencies {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -11,9 +11,8 @@ buildscript {
         ndkVersion = "23.1.7779620"
     }
     repositories {
-        maven {
-            url "gcs://snapengine-maven-publish/releases"
-        }
+        google()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle")

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - camera-kit-react-native (0.2.0):
+  - camera-kit-react-native (0.3.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - SCCameraKit
@@ -581,7 +581,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  camera-kit-react-native: 7c28fe4ca2e7bc9caae183187b9570ae698f21fa
+  camera-kit-react-native: 2378f165123e067664b67f8b3c5c7d8803aba23c
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5fbbff1d7734827299274638deb8ba3024f6c597
   FBReactNativeSpec: 638095fe8a01506634d77b260ef8a322019ac671

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/camera-kit-react-native",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Camera Kit wrapper for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Background (Why?)

Repo is using not publicly available repository gcs://snapengine-maven-publish/releases which is preventing from building the solution

## Change/Solution (What?)

Replace 
```
        maven {
            url "gcs://snapengine-maven-publish/releases"
        }
```
by
```
    google()
    mavenCentral()
```
Based on the PR https://github.com/Snapchat/camera-kit-react-native/pull/2 

## Screenshots for any visual changes

N/A

## Test Plans

Manually validated on iOS and Android devices
