### PR TITLE
Repo update to Camera Kit SDK version 1.37

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["CameraKitReactNative_kotlinVersion"]
 
     ext {
-        cameraKitVersion = "1.34.0"
+        cameraKitVersion = "1.37.0"
         exoPlayerVersion = "2.16.1"
     }
 

--- a/example/README.md
+++ b/example/README.md
@@ -10,7 +10,7 @@ Also, make sure you have completed the [React Native - Environment Setup](https:
 
 1. Open `App.tsx` in and enter value for `apiToken` with the one you get from Camera Kit Developer portal.
 2. Open `Lenses.tsx` and enter value for `groupId` from which you want to fetch lenses. [Optional] Enter value for `launchDataLensId` for the Lens which has launch data associated with it or remove all the relevant code that uses this param.
-3. [_Optional_] This example is using version 1.34.0 of Camera Kit Mobile SDK for Android and latest version on iOS. If you want to use the [latest version](https://docs.snap.com/camera-kit/integrate-sdk/mobile/changelog-mobile#latest-version) of Camera Kit Mobile SDK on Android then modify `cameraKitVersion` variable in [build.gradle](../android/build.gradle) file. Please refer to [Lens Studio Compatibility](https://docs.snap.com/camera-kit/ar-content/lens-studio-compatibility) guide for selecting the appropriate version that work with your Lenses.
+3. [_Optional_] This example is using version 1.37.0 of Camera Kit Mobile SDK for Android and latest version on iOS. If you want to use the [latest version](https://docs.snap.com/camera-kit/integrate-sdk/mobile/changelog-mobile#latest-version) of Camera Kit Mobile SDK on Android then modify `cameraKitVersion` variable in [build.gradle](../android/build.gradle) file. Please refer to [Lens Studio Compatibility](https://docs.snap.com/camera-kit/ar-content/lens-studio-compatibility) guide for selecting the appropriate version that work with your Lenses.
 
 ## Step 2: Start the Metro Server
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -435,9 +435,9 @@ PODS:
     - React-jsi (= 0.72.7)
     - React-logger (= 0.72.7)
     - React-perflogger (= 0.72.7)
-  - SCCameraKit (1.34.0)
-  - SCCameraKitReferenceUI (1.34.0):
-    - SCCameraKit (~> 1.34.0)
+  - SCCameraKit (1.37.0)
+  - SCCameraKitReferenceUI (1.37.0):
+    - SCCameraKit (~> 1.37.0)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
 
@@ -622,11 +622,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  SCCameraKit: 1d7a49ff634413d2609d06176d09c7020ab4e249
-  SCCameraKitReferenceUI: 64705e5e021714e1985cf375322a76bba7cb7a4c
+  SCCameraKit: ca372a618888ea228b3e7887812a7bc0a18e085c
+  SCCameraKitReferenceUI: 630c3d670810bb5e556d8fe7be25b72391ad344f
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: a7b8a6ac21f77ed63837303858cfdd4fd9428df8
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/camera-kit-react-native",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Camera Kit wrapper for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Background (Why?)

To update the repo to the latest version of the Camera Kit SDK - 1.37.0

## Change/Solution (What?)

SDK version update

## Screenshots for any visual changes

N/A

## Test Plans

Manually validated on iOS and Android device
