### PR TITLE
Repo update to Camera Kit SDK version 1.38

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["CameraKitReactNative_kotlinVersion"]
 
     ext {
-        cameraKitVersion = "1.37.0"
+        cameraKitVersion = "1.38.0"
         exoPlayerVersion = "2.16.1"
     }
 

--- a/example/README.md
+++ b/example/README.md
@@ -10,7 +10,7 @@ Also, make sure you have completed the [React Native - Environment Setup](https:
 
 1. Open `App.tsx` in and enter value for `apiToken` with the one you get from Camera Kit Developer portal.
 2. Open `Lenses.tsx` and enter value for `groupId` from which you want to fetch lenses. [Optional] Enter value for `launchDataLensId` for the Lens which has launch data associated with it or remove all the relevant code that uses this param.
-3. [_Optional_] This example is using version 1.37.0 of Camera Kit Mobile SDK for Android and latest version on iOS. If you want to use the [latest version](https://docs.snap.com/camera-kit/integrate-sdk/mobile/changelog-mobile#latest-version) of Camera Kit Mobile SDK on Android then modify `cameraKitVersion` variable in [build.gradle](../android/build.gradle) file. Please refer to [Lens Studio Compatibility](https://docs.snap.com/camera-kit/ar-content/lens-studio-compatibility) guide for selecting the appropriate version that work with your Lenses.
+3. [_Optional_] This example is using version 1.38.0 of Camera Kit Mobile SDK for Android and latest version on iOS. If you want to use the [latest version](https://docs.snap.com/camera-kit/integrate-sdk/mobile/changelog-mobile#latest-version) of Camera Kit Mobile SDK on Android then modify `cameraKitVersion` variable in [build.gradle](../android/build.gradle) file. Please refer to [Lens Studio Compatibility](https://docs.snap.com/camera-kit/ar-content/lens-studio-compatibility) guide for selecting the appropriate version that work with your Lenses.
 
 ## Step 2: Start the Metro Server
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - camera-kit-react-native (0.3.0):
+  - camera-kit-react-native (0.4.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - SCCameraKit
@@ -435,9 +435,9 @@ PODS:
     - React-jsi (= 0.72.7)
     - React-logger (= 0.72.7)
     - React-perflogger (= 0.72.7)
-  - SCCameraKit (1.37.0)
-  - SCCameraKitReferenceUI (1.37.0):
-    - SCCameraKit (~> 1.37.0)
+  - SCCameraKit (1.38.0)
+  - SCCameraKitReferenceUI (1.38.0):
+    - SCCameraKit (~> 1.38.0)
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
 
@@ -581,7 +581,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  camera-kit-react-native: 2378f165123e067664b67f8b3c5c7d8803aba23c
+  camera-kit-react-native: 62c23d50e86360c4a1eee9295fe0a6e39351cd9a
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5fbbff1d7734827299274638deb8ba3024f6c597
   FBReactNativeSpec: 638095fe8a01506634d77b260ef8a322019ac671
@@ -622,8 +622,8 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  SCCameraKit: ca372a618888ea228b3e7887812a7bc0a18e085c
-  SCCameraKitReferenceUI: 630c3d670810bb5e556d8fe7be25b72391ad344f
+  SCCameraKit: e74fb3d2cd0049abd6f02b9af3e15777fcc96f1d
+  SCCameraKitReferenceUI: 628cb47217e2c93719c342452cce482672c08754
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - camera-kit-react-native (0.4.0):
+  - camera-kit-react-native (0.5.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - SCCameraKit
@@ -581,7 +581,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  camera-kit-react-native: 62c23d50e86360c4a1eee9295fe0a6e39351cd9a
+  camera-kit-react-native: 8114061da22ae1feb6c795c5e6e83c55a5d10193
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5fbbff1d7734827299274638deb8ba3024f6c597
   FBReactNativeSpec: 638095fe8a01506634d77b260ef8a322019ac671

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snap/camera-kit-react-native",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Camera Kit wrapper for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
SDK Update to 1.38.0

## Background (Why?)

To update the repo to the latest version of the Camera Kit SDK - 1.38.0

## Change/Solution (What?)

SDK version update

## Screenshots for any visual changes

N/A

## Test Plans

Manually validated on iOS and Android device
